### PR TITLE
Peer sem ver

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "device",
     "detection"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "react-native": ">=0.4.0 <=1.0.0"
   },
   "author": "Gertjan Reynaert",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "detection"
   ],
   "dependencies": {
-    "react-native": "^0.4.0"
+    "react-native": ">=0.4.0 <=1.0.0"
   },
   "author": "Gertjan Reynaert",
   "license": "MIT"


### PR DESCRIPTION
Very useful module :). Thank you 

Could you please change **dependencies** to **peerDependencies** for react-native.
Also ^ does not work well for versions starting from 0.x. I found this discussion [special-case for 0.x in ^ is very counter-intuitive and rage-inducing #79](https://github.com/npm/node-semver/issues/79)

I changed the versioning to reflect your intended use of the caret
