### PR TITLE
Fix broken React Native dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "device",
     "detection"
   ],
-  "dependencies": {
-    "react-native": "^0.4.0"
-  },
   "author": "Gertjan Reynaert",
   "license": "MIT"
 }


### PR DESCRIPTION
Declaring `React Native` as dependency wasn't needed for this module to work.
By removing the dependency, this module should keep working, independent of `React Native` updates.

To @pgmemk and @wootwoot1234: thanks for making me aware of the issue and proposing a solution.
